### PR TITLE
Update to Unity 2020.2

### DIFF
--- a/Assets/UGF.Update.Runtime.Tests/TestUpdateCollection.cs
+++ b/Assets/UGF.Update.Runtime.Tests/TestUpdateCollection.cs
@@ -17,7 +17,7 @@ namespace UGF.Update.Runtime.Tests
         }
     }
 
-    public abstract class TestUpdateCollection<TTarget> where TTarget : ITestTarget
+    public abstract class TestUpdateCollection<TTarget> where TTarget : class, ITestTarget
     {
         protected abstract IUpdateCollection<TTarget> CreateCollection();
         protected abstract TTarget CreateTarget();

--- a/Assets/UGF.Update.Runtime.Tests/TestUpdateExtensions.cs
+++ b/Assets/UGF.Update.Runtime.Tests/TestUpdateExtensions.cs
@@ -52,9 +52,9 @@ namespace UGF.Update.Runtime.Tests
 
             provider.Add(typeof(UnityEngine.PlayerLoop.Update), group);
 
-            string path0 = "root.one.two.three";
-            string path1 = "root.one.two";
-            string path2 = "root.one";
+            string path0 = "root/one/two/three";
+            string path1 = "root/one/two";
+            string path2 = "root/one";
             string path3 = "root";
             string path4 = "group";
 
@@ -81,8 +81,8 @@ namespace UGF.Update.Runtime.Tests
         {
             Group group = CreateGroups();
 
-            string path0 = "one.two.three";
-            string path1 = "one.two";
+            string path0 = "one/two/three";
+            string path1 = "one/two";
             string path2 = "one";
             string path3 = "root";
 
@@ -109,9 +109,9 @@ namespace UGF.Update.Runtime.Tests
 
             provider.Add(typeof(UnityEngine.PlayerLoop.Update), group);
 
-            string path0 = "root.one.two.three";
-            string path1 = "root.one.two";
-            string path2 = "root.one";
+            string path0 = "root/one/two/three";
+            string path1 = "root/one/two";
+            string path2 = "root/one";
             string path3 = "root";
             string path4 = "group";
 
@@ -142,8 +142,8 @@ namespace UGF.Update.Runtime.Tests
         {
             Group group = CreateGroups();
 
-            string path0 = "one.two.three";
-            string path1 = "one.two";
+            string path0 = "one/two/three";
+            string path1 = "one/two";
             string path2 = "one";
             string path3 = "root";
 

--- a/Packages/UGF.Update.meta
+++ b/Packages/UGF.Update.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 04d48f20d5a14798be32aade4dbb2b6b
+timeCreated: 1605450910

--- a/Packages/UGF.Update/Runtime/IUpdateCollection`1.cs
+++ b/Packages/UGF.Update/Runtime/IUpdateCollection`1.cs
@@ -5,7 +5,7 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update collection with the specified type of the item.
     /// </summary>
-    public interface IUpdateCollection<TItem> : IUpdateCollection, IEnumerable<TItem>
+    public interface IUpdateCollection<TItem> : IUpdateCollection, IEnumerable<TItem> where TItem : class
     {
         /// <summary>
         /// Gets the queue of the collection.

--- a/Packages/UGF.Update/Runtime/IUpdateGroup`1.cs
+++ b/Packages/UGF.Update/Runtime/IUpdateGroup`1.cs
@@ -3,7 +3,7 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update group with the specified type of the update collection.
     /// </summary>
-    public interface IUpdateGroup<TItem> : IUpdateGroup
+    public interface IUpdateGroup<TItem> : IUpdateGroup where TItem : class
     {
         /// <summary>
         /// Gets the update collection.

--- a/Packages/UGF.Update/Runtime/UpdateCollection.cs
+++ b/Packages/UGF.Update/Runtime/UpdateCollection.cs
@@ -7,7 +7,7 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents abstract implementation of the update collection.
     /// </summary>
-    public abstract class UpdateCollection<TItem> : IUpdateCollection<TItem>
+    public abstract class UpdateCollection<TItem> : IUpdateCollection<TItem> where TItem : class
     {
         public int Count { get { return Collection.Count; } }
         public IUpdateQueue<TItem> Queue { get; }
@@ -32,12 +32,14 @@ namespace UGF.Update.Runtime
 
         public bool Contains(TItem item)
         {
+            if (item == null) throw new ArgumentNullException(nameof(item));
+
             return Collection.Contains(item);
         }
 
         public void Add(TItem item)
         {
-            if (typeof(TItem).IsClass && EqualityComparer<TItem>.Default.Equals(item, default)) throw new ArgumentNullException(nameof(item));
+            if (item == null) throw new ArgumentNullException(nameof(item));
 
             Queue.Add.Add(item);
             Queue.Remove.Remove(item);
@@ -45,7 +47,7 @@ namespace UGF.Update.Runtime
 
         public void Remove(TItem item)
         {
-            if (typeof(TItem).IsClass && EqualityComparer<TItem>.Default.Equals(item, default)) throw new ArgumentNullException(nameof(item));
+            if (item == null) throw new ArgumentNullException(nameof(item));
 
             Queue.Add.Remove(item);
             Queue.Remove.Add(item);

--- a/Packages/UGF.Update/Runtime/UpdateExtensions.cs
+++ b/Packages/UGF.Update/Runtime/UpdateExtensions.cs
@@ -6,14 +6,11 @@ namespace UGF.Update.Runtime
 {
     public static class UpdateExtensions
     {
-        private static readonly char[] m_pathSeparatorDefault = { '.' };
+        private static readonly char[] m_separator = { '/' };
 
         /// <summary>
         /// Tries to find collection from the group by the specified path.
         /// </summary>
-        /// <remarks>
-        /// The path separator is dot. ('.')
-        /// </remarks>
         /// <param name="updateProvider">The update provider.</param>
         /// <param name="path">The path of the group to find.</param>
         /// <param name="collection">The found collection.</param>
@@ -22,9 +19,9 @@ namespace UGF.Update.Runtime
             if (updateProvider == null) throw new ArgumentNullException(nameof(updateProvider));
             if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
 
-            if (TryFindGroup(updateProvider, path, out IUpdateGroup group) && group.Collection is T cast)
+            if (TryFindGroup(updateProvider, path, out IUpdateGroup result))
             {
-                collection = cast;
+                collection = (T)result.Collection;
                 return true;
             }
 
@@ -35,9 +32,6 @@ namespace UGF.Update.Runtime
         /// <summary>
         /// Tries to find collection from the group by the specified path.
         /// </summary>
-        /// <remarks>
-        /// The path separator is dot. ('.')
-        /// </remarks>
         /// <param name="updateGroup">The update group.</param>
         /// <param name="path">The path of the group to find.</param>
         /// <param name="collection">The found collection.</param>
@@ -46,9 +40,9 @@ namespace UGF.Update.Runtime
             if (updateGroup == null) throw new ArgumentNullException(nameof(updateGroup));
             if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
 
-            if (TryFindGroup(updateGroup, path, out IUpdateGroup group) && group.Collection is T cast)
+            if (TryFindGroup(updateGroup, path, out IUpdateGroup result))
             {
-                collection = cast;
+                collection = (T)result.Collection;
                 return true;
             }
 
@@ -59,9 +53,6 @@ namespace UGF.Update.Runtime
         /// <summary>
         /// Tries to find group by the specified path.
         /// </summary>
-        /// <remarks>
-        /// The path separator is dot. ('.')
-        /// </remarks>
         /// <param name="updateProvider">The update provider.</param>
         /// <param name="path">The path of the group to find.</param>
         /// <param name="group">The found group.</param>
@@ -70,21 +61,21 @@ namespace UGF.Update.Runtime
             if (updateProvider == null) throw new ArgumentNullException(nameof(updateProvider));
             if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
 
-            string[] split = path.Split(m_pathSeparatorDefault);
+            string[] split = path.Split(m_separator);
 
-            if (split.Length > 0 && updateProvider.Groups.TryGetValue(split[0], out IUpdateGroup updateGroup))
+            if (split.Length > 0 && updateProvider.Groups.TryGetValue(split[0], out IUpdateGroup result))
             {
                 if (split.Length > 1)
                 {
-                    if (TryFindGroup(updateGroup, split, 1, out IUpdateGroup result) && result is T cast)
+                    if (TryFindGroup(result, split, 1, out result))
                     {
-                        group = cast;
+                        group = (T)result;
                         return true;
                     }
                 }
-                else if (updateGroup is T cast)
+                else
                 {
-                    group = cast;
+                    group = (T)result;
                     return true;
                 }
             }
@@ -96,9 +87,6 @@ namespace UGF.Update.Runtime
         /// <summary>
         /// Tries to find group by the specified path.
         /// </summary>
-        /// <remarks>
-        /// The path separator is dot. ('.')
-        /// </remarks>
         /// <param name="updateGroup">The update group.</param>
         /// <param name="path">The path of the group to find.</param>
         /// <param name="group">The found group.</param>
@@ -107,11 +95,11 @@ namespace UGF.Update.Runtime
             if (updateGroup == null) throw new ArgumentNullException(nameof(updateGroup));
             if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
 
-            string[] split = path.Split(m_pathSeparatorDefault);
+            string[] split = path.Split(m_separator);
 
-            if (split.Length > 0 && TryFindGroup(updateGroup, split, 0, out IUpdateGroup result) && result is T cast)
+            if (split.Length > 0 && TryFindGroup(updateGroup, split, 0, out IUpdateGroup result))
             {
-                group = cast;
+                group = (T)result;
                 return true;
             }
 

--- a/Packages/UGF.Update/Runtime/UpdateGroup.cs
+++ b/Packages/UGF.Update/Runtime/UpdateGroup.cs
@@ -58,11 +58,7 @@ namespace UGF.Update.Runtime
             if (group == null) throw new ArgumentNullException(nameof(group));
             if (group == this) throw new ArgumentException("Update group cannot contains itself.", nameof(group));
             if (index < 0 || index > m_subGroups.Count) throw new ArgumentOutOfRangeException(nameof(index));
-
-            if (m_subGroupsByName.ContainsKey(group.Name))
-            {
-                throw new ArgumentException($"A group with the same name already exists: '{group.Name}'.", nameof(group));
-            }
+            if (m_subGroupsByName.ContainsKey(group.Name)) throw new ArgumentException($"A group with the same name already exists: '{group.Name}'.", nameof(group));
 
             m_subGroups.Insert(index, group);
             m_subGroupsByName.Add(group.Name, group);
@@ -72,11 +68,7 @@ namespace UGF.Update.Runtime
         {
             if (group == null) throw new ArgumentNullException(nameof(group));
             if (group == this) throw new ArgumentException("Update group cannot contains itself.", nameof(group));
-
-            if (m_subGroupsByName.ContainsKey(group.Name))
-            {
-                throw new ArgumentException($"A group with the same name already exists: '{group.Name}'.", nameof(group));
-            }
+            if (m_subGroupsByName.ContainsKey(group.Name)) throw new ArgumentException($"A group with the same name already exists: '{group.Name}'.", nameof(group));
 
             m_subGroups.Add(group);
             m_subGroupsByName.Add(group.Name, group);
@@ -109,10 +101,7 @@ namespace UGF.Update.Runtime
 
         public void Update()
         {
-            if (m_updating)
-            {
-                throw new InvalidOperationException("The update group already updating, possible recursive call.");
-            }
+            if (m_updating) throw new InvalidOperationException("Update group already updating, possible recursive call.");
 
             if (Enable)
             {
@@ -133,35 +122,23 @@ namespace UGF.Update.Runtime
 
         public T GetSubGroup<T>(string name) where T : IUpdateGroup
         {
-            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
-
-            if (!m_subGroupsByName.TryGetValue(name, out IUpdateGroup group))
-            {
-                throw new ArgumentException($"A group by the specified name not found: '{name}'.");
-            }
-
-            return (T)group;
+            return (T)GetSubGroup(name);
         }
 
         public IUpdateGroup GetSubGroup(string name)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
 
-            if (!m_subGroupsByName.TryGetValue(name, out IUpdateGroup group))
-            {
-                throw new ArgumentException($"A group by the specified name not found: '{name}'.");
-            }
-
-            return group;
+            return m_subGroupsByName.TryGetValue(name, out IUpdateGroup group) ? group : throw new ArgumentException($"Group not found by the specified name: '{name}'.");
         }
 
         public bool TryGetSubGroup<T>(string name, out T group) where T : IUpdateGroup
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
 
-            if (m_subGroupsByName.TryGetValue(name, out IUpdateGroup value) && value is T cast)
+            if (m_subGroupsByName.TryGetValue(name, out IUpdateGroup value))
             {
-                group = cast;
+                group = (T)value;
                 return true;
             }
 

--- a/Packages/UGF.Update/Runtime/UpdateGroup`1.cs
+++ b/Packages/UGF.Update/Runtime/UpdateGroup`1.cs
@@ -3,7 +3,7 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents generic implementation of the UpdateGroup.
     /// </summary>
-    public class UpdateGroup<TItem> : UpdateGroup, IUpdateGroup<TItem>
+    public class UpdateGroup<TItem> : UpdateGroup, IUpdateGroup<TItem> where TItem : class
     {
         public new IUpdateCollection<TItem> Collection { get; }
 

--- a/Packages/UGF.Update/Runtime/UpdateList.cs
+++ b/Packages/UGF.Update/Runtime/UpdateList.cs
@@ -5,15 +5,22 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update collection as ordered list of the items where each of them implements 'IUpdateHandler' interface.
     /// </summary>
-    public class UpdateList<TItem> : UpdateCollection<TItem> where TItem : IUpdateHandler
+    public class UpdateList<TItem> : UpdateCollection<TItem> where TItem : class, IUpdateHandler
     {
         private readonly List<TItem> m_items;
 
         /// <summary>
+        /// Creates update list with the UpdateQueueSet queue.
+        /// </summary>
+        public UpdateList() : this(new UpdateQueueSet<TItem>())
+        {
+        }
+
+        /// <summary>
         /// Creates update list with the specified update queue.
         /// </summary>
-        /// <param name="queue">The update queue. (Default value is UpdateQueueSet)</param>
-        public UpdateList(IUpdateQueue<TItem> queue = null) : base(new List<TItem>(), queue ?? new UpdateQueueSet<TItem>())
+        /// <param name="queue">The update queue.</param>
+        public UpdateList(IUpdateQueue<TItem> queue) : base(new List<TItem>(), queue)
         {
             m_items = (List<TItem>)Collection;
         }

--- a/Packages/UGF.Update/Runtime/UpdateListHandler.cs
+++ b/Packages/UGF.Update/Runtime/UpdateListHandler.cs
@@ -6,18 +6,26 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update collection as ordered list with the specified handler to update each item.
     /// </summary>
-    public class UpdateListHandler<TItem> : UpdateCollection<TItem>
+    public class UpdateListHandler<TItem> : UpdateCollection<TItem> where TItem : class
     {
         public UpdateHandler<TItem> Handler { get; }
 
         private readonly List<TItem> m_items;
 
         /// <summary>
+        /// Creates update list with the specified handler and UpdateQueueSet queue.
+        /// </summary>
+        /// <param name="handler">The handler to update each item.</param>
+        public UpdateListHandler(UpdateHandler<TItem> handler) : this(handler, new UpdateQueueSet<TItem>())
+        {
+        }
+
+        /// <summary>
         /// Creates update list with the specified handler and update queue.
         /// </summary>
         /// <param name="handler">The handler to update each item.</param>
-        /// <param name="queue">The update queue. (Default value is UpdateQueueSet)</param>
-        public UpdateListHandler(UpdateHandler<TItem> handler, IUpdateQueue<TItem> queue = null) : base(new List<TItem>(), queue ?? new UpdateQueueSet<TItem>())
+        /// <param name="queue">The update queue.</param>
+        public UpdateListHandler(UpdateHandler<TItem> handler, IUpdateQueue<TItem> queue) : base(new List<TItem>(), queue)
         {
             Handler = handler ?? throw new ArgumentNullException(nameof(handler));
 

--- a/Packages/UGF.Update/Runtime/UpdateQueueSet.cs
+++ b/Packages/UGF.Update/Runtime/UpdateQueueSet.cs
@@ -9,25 +9,22 @@ namespace UGF.Update.Runtime
     /// </summary>
     public class UpdateQueueSet<TItem> : IUpdateQueue<TItem>
     {
-        public bool AnyQueued { get { return m_add.Count > 0 || m_remove.Count > 0; } }
+        public bool AnyQueued { get { return Add.Count > 0 || Remove.Count > 0; } }
 
         /// <summary>
         /// Gets the collection of the objects queued to add.
         /// </summary>
-        public HashSet<TItem> Add { get { return m_add; } }
+        public HashSet<TItem> Add { get; } = new HashSet<TItem>();
 
         /// <summary>
         /// Gets the collection of the objects queued to remove.
         /// </summary>
-        public HashSet<TItem> Remove { get { return m_remove; } }
+        public HashSet<TItem> Remove { get; } = new HashSet<TItem>();
 
-        ICollection<TItem> IUpdateQueue<TItem>.Add { get { return m_add; } }
-        ICollection<TItem> IUpdateQueue<TItem>.Remove { get { return m_remove; } }
-        IEnumerable IUpdateQueue.Add { get { return m_add; } }
-        IEnumerable IUpdateQueue.Remove { get { return m_remove; } }
-
-        private readonly HashSet<TItem> m_add = new HashSet<TItem>();
-        private readonly HashSet<TItem> m_remove = new HashSet<TItem>();
+        ICollection<TItem> IUpdateQueue<TItem>.Add { get { return Add; } }
+        ICollection<TItem> IUpdateQueue<TItem>.Remove { get { return Remove; } }
+        IEnumerable IUpdateQueue.Add { get { return Add; } }
+        IEnumerable IUpdateQueue.Remove { get { return Remove; } }
 
         public bool Apply(ICollection<TItem> collection)
         {
@@ -35,18 +32,18 @@ namespace UGF.Update.Runtime
 
             if (AnyQueued)
             {
-                foreach (TItem item in m_add)
+                foreach (TItem item in Add)
                 {
                     collection.Add(item);
                 }
 
-                foreach (TItem item in m_remove)
+                foreach (TItem item in Remove)
                 {
                     collection.Remove(item);
                 }
 
-                m_add.Clear();
-                m_remove.Clear();
+                Add.Clear();
+                Remove.Clear();
 
                 return true;
             }

--- a/Packages/UGF.Update/Runtime/UpdateSet.cs
+++ b/Packages/UGF.Update/Runtime/UpdateSet.cs
@@ -5,7 +5,7 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update collection as unordered set of the items where each of them implements 'IUpdateHandler' interface.
     /// </summary>
-    public class UpdateSet<TItem> : UpdateCollection<TItem> where TItem : IUpdateHandler
+    public class UpdateSet<TItem> : UpdateCollection<TItem> where TItem : class, IUpdateHandler
     {
         private readonly HashSet<TItem> m_items;
 

--- a/Packages/UGF.Update/Runtime/UpdateSetHandler.cs
+++ b/Packages/UGF.Update/Runtime/UpdateSetHandler.cs
@@ -6,18 +6,26 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update collection as unordered set with the specified handler to update each item.
     /// </summary>
-    public class UpdateSetHandler<TItem> : UpdateCollection<TItem>
+    public class UpdateSetHandler<TItem> : UpdateCollection<TItem> where TItem : class
     {
         public UpdateHandler<TItem> Handler { get; }
 
         private readonly HashSet<TItem> m_items;
 
         /// <summary>
+        /// Creates update set with the specified handler and UpdateQueueSet queue.
+        /// </summary>
+        /// <param name="handler">The handler to update each item.</param>
+        public UpdateSetHandler(UpdateHandler<TItem> handler) : this(handler, new UpdateQueueSet<TItem>())
+        {
+        }
+
+        /// <summary>
         /// Creates update set with the specified handler and update queue.
         /// </summary>
         /// <param name="handler">The handler to update each item.</param>
-        /// <param name="queue">The update queue. (Default value is UpdateQueueSet)</param>
-        public UpdateSetHandler(UpdateHandler<TItem> handler, IUpdateQueue<TItem> queue = null) : base(new HashSet<TItem>(), queue ?? new UpdateQueueSet<TItem>())
+        /// <param name="queue">The update queue.</param>
+        public UpdateSetHandler(UpdateHandler<TItem> handler, IUpdateQueue<TItem> queue) : base(new HashSet<TItem>(), queue)
         {
             Handler = handler ?? throw new ArgumentNullException(nameof(handler));
 


### PR DESCRIPTION
- Change `TItem` generic constraint for all groups to be a class.
- Change find by path extensions to use forward flash (`/`) as separator instead of dot (`.`).