### PR TITLE
Remove inheritance of update function pointer when add subsystem

### DIFF
--- a/Assets/UGF.Update.Runtime.Tests/TestUpdateUtility.cs
+++ b/Assets/UGF.Update.Runtime.Tests/TestUpdateUtility.cs
@@ -514,7 +514,7 @@ namespace UGF.Update.Runtime.Tests
                 }
             };
 
-            UpdateUtility.AddSubSystem(ref playerLoop, typeof(PlayerLoops.FixedUpdate), IntPtr.Zero, 1);
+            UpdateUtility.AddSubSystem(ref playerLoop, typeof(PlayerLoops.FixedUpdate), 1);
 
             Assert.AreEqual(4, playerLoop.subSystemList.Length);
             Assert.AreEqual(typeof(PlayerLoops.PreUpdate), playerLoop.subSystemList[0].type);

--- a/Packages/UGF.Update/Runtime/UpdateUtility.cs
+++ b/Packages/UGF.Update/Runtime/UpdateUtility.cs
@@ -98,17 +98,17 @@ namespace UGF.Update.Runtime
                         {
                             case UpdateSubSystemInsertion.Before:
                             {
-                                AddSubSystem(ref playerLoop, subSystemType, subSystem.updateFunction, i);
+                                AddSubSystem(ref playerLoop, subSystemType, IntPtr.Zero, i);
                                 break;
                             }
                             case UpdateSubSystemInsertion.After:
                             {
-                                AddSubSystem(ref playerLoop, subSystemType, subSystem.updateFunction, i + 1);
+                                AddSubSystem(ref playerLoop, subSystemType, IntPtr.Zero, i + 1);
                                 break;
                             }
                             case UpdateSubSystemInsertion.InsideTop:
                             {
-                                AddSubSystem(ref subSystem, subSystemType, subSystem.updateFunction, 0);
+                                AddSubSystem(ref subSystem, subSystemType, IntPtr.Zero, 0);
 
                                 subSystems[i] = subSystem;
                                 break;
@@ -117,7 +117,7 @@ namespace UGF.Update.Runtime
                             {
                                 int index = subSystem.subSystemList?.Length ?? 0;
 
-                                AddSubSystem(ref subSystem, subSystemType, subSystem.updateFunction, index);
+                                AddSubSystem(ref subSystem, subSystemType, IntPtr.Zero, index);
 
                                 subSystems[i] = subSystem;
                                 break;
@@ -171,6 +171,17 @@ namespace UGF.Update.Runtime
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Adds subsystem with the specified type at the specified index into player loop system.
+        /// </summary>
+        /// <param name="playerLoop">The player loop system to change.</param>
+        /// <param name="subSystemType">The type of the subsystem to add.</param>
+        /// <param name="index">The index of the subsystem.</param>
+        public static void AddSubSystem(ref PlayerLoopSystem playerLoop, Type subSystemType, int index)
+        {
+            AddSubSystem(ref playerLoop, subSystemType, IntPtr.Zero, index);
         }
 
         /// <summary>


### PR DESCRIPTION
- Add `UpdateUtility.AddSubSystem` without update function argument to add subsystem with empty update function pointer.
- Change `UpdateUtility.TryAddSubSystem` to add subsystems without update function pointer inherited from parent.