### PR TITLE
Extend IUpdateLoop to manage player loop

### DIFF
--- a/Assets/UGF.Update.Runtime.Tests/TestUpdateExtensions.cs
+++ b/Assets/UGF.Update.Runtime.Tests/TestUpdateExtensions.cs
@@ -5,28 +5,34 @@ namespace UGF.Update.Runtime.Tests
 {
     public class TestUpdateExtensions
     {
-        private class Loop : IUpdateLoop
+        private class Loop : UpdateLoopBase
         {
-            private PlayerLoopSystem m_playerLoop = new PlayerLoopSystem
-            {
-                subSystemList = new[]
-                {
-                    new PlayerLoopSystem { type = typeof(UnityEngine.PlayerLoop.Update) }
-                }
-            };
+            private PlayerLoopSystem m_playerLoop;
 
-            public PlayerLoopSystem GetPlayerLoop()
+            public Loop()
+            {
+                Reset();
+            }
+
+            protected override PlayerLoopSystem OnGetPlayerLoop()
             {
                 return m_playerLoop;
             }
 
-            public void SetPlayerLoop(PlayerLoopSystem playerLoop)
+            protected override void OnSetPlayerLoop(PlayerLoopSystem playerLoop)
             {
                 m_playerLoop = playerLoop;
             }
 
-            public void Reset()
+            protected override void OnReset()
             {
+                m_playerLoop = new PlayerLoopSystem
+                {
+                    subSystemList = new[]
+                    {
+                        new PlayerLoopSystem { type = typeof(UnityEngine.PlayerLoop.Update) }
+                    }
+                };
             }
         }
 

--- a/Assets/UGF.Update.Runtime.Tests/TestUpdateProvider.cs
+++ b/Assets/UGF.Update.Runtime.Tests/TestUpdateProvider.cs
@@ -8,30 +8,36 @@ namespace UGF.Update.Runtime.Tests
 {
     public class TestUpdateProvider
     {
-        private class Loop : IUpdateLoop
+        private class Loop : UpdateLoopBase
         {
-            private PlayerLoopSystem m_playerLoop = new PlayerLoopSystem
-            {
-                subSystemList = new[]
-                {
-                    new PlayerLoopSystem { type = typeof(PlayerLoops.PreUpdate) },
-                    new PlayerLoopSystem { type = typeof(PlayerLoops.Update) },
-                    new PlayerLoopSystem { type = typeof(PlayerLoops.PostLateUpdate) }
-                }
-            };
+            private PlayerLoopSystem m_playerLoop;
 
-            public PlayerLoopSystem GetPlayerLoop()
+            public Loop()
+            {
+                Reset();
+            }
+
+            protected override PlayerLoopSystem OnGetPlayerLoop()
             {
                 return m_playerLoop;
             }
 
-            public void SetPlayerLoop(PlayerLoopSystem playerLoop)
+            protected override void OnSetPlayerLoop(PlayerLoopSystem playerLoop)
             {
                 m_playerLoop = playerLoop;
             }
 
-            public void Reset()
+            protected override void OnReset()
             {
+                m_playerLoop = new PlayerLoopSystem
+                {
+                    subSystemList = new[]
+                    {
+                        new PlayerLoopSystem { type = typeof(PlayerLoops.PreUpdate) },
+                        new PlayerLoopSystem { type = typeof(PlayerLoops.Update) },
+                        new PlayerLoopSystem { type = typeof(PlayerLoops.PostLateUpdate) }
+                    }
+                };
             }
         }
 

--- a/Packages/UGF.Update/Runtime/IUpdateLoop.cs
+++ b/Packages/UGF.Update/Runtime/IUpdateLoop.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine.LowLevel;
 
 namespace UGF.Update.Runtime
@@ -7,6 +8,12 @@ namespace UGF.Update.Runtime
     /// </summary>
     public interface IUpdateLoop
     {
+        bool Contains(Type systemType);
+        void Add(Type targetSystem, Type systemType, UpdateSubSystemInsertion insertion);
+        bool Remove(Type systemType);
+        void AddFunction(Type systemType, PlayerLoopSystem.UpdateFunction updateFunction);
+        void RemoveFunction(Type systemType, PlayerLoopSystem.UpdateFunction updateFunction);
+
         /// <summary>
         /// Gets current player loop.
         /// </summary>
@@ -19,7 +26,7 @@ namespace UGF.Update.Runtime
         void SetPlayerLoop(PlayerLoopSystem playerLoop);
 
         /// <summary>
-        /// Resets Unity player loop to default.
+        /// Resets player loop to default.
         /// </summary>
         void Reset();
     }

--- a/Packages/UGF.Update/Runtime/UpdateLoopBase.cs
+++ b/Packages/UGF.Update/Runtime/UpdateLoopBase.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using UnityEngine.LowLevel;
+
+namespace UGF.Update.Runtime
+{
+    public abstract class UpdateLoopBase : IUpdateLoop
+    {
+        public bool Contains(Type systemType)
+        {
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
+
+            return OnContains(systemType);
+        }
+
+        public void Add(Type targetSystem, Type systemType, UpdateSubSystemInsertion insertion)
+        {
+            if (targetSystem == null) throw new ArgumentNullException(nameof(targetSystem));
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
+
+            OnAdd(targetSystem, systemType, insertion);
+        }
+
+        public bool Remove(Type systemType)
+        {
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
+
+            return OnRemove(systemType);
+        }
+
+        public void AddFunction(Type systemType, PlayerLoopSystem.UpdateFunction updateFunction)
+        {
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
+            if (updateFunction == null) throw new ArgumentNullException(nameof(updateFunction));
+
+            OnAddFunction(systemType, updateFunction);
+        }
+
+        public void RemoveFunction(Type systemType, PlayerLoopSystem.UpdateFunction updateFunction)
+        {
+            if (systemType == null) throw new ArgumentNullException(nameof(systemType));
+            if (updateFunction == null) throw new ArgumentNullException(nameof(updateFunction));
+
+            OnRemoveFunction(systemType, updateFunction);
+        }
+
+        public PlayerLoopSystem GetPlayerLoop()
+        {
+            return OnGetPlayerLoop();
+        }
+
+        public void SetPlayerLoop(PlayerLoopSystem playerLoop)
+        {
+            OnSetPlayerLoop(playerLoop);
+        }
+
+        public void Reset()
+        {
+            OnReset();
+        }
+
+        protected virtual bool OnContains(Type systemType)
+        {
+            PlayerLoopSystem playerLoop = GetPlayerLoop();
+
+            return UpdateUtility.ContainsSubSystem(playerLoop, systemType);
+        }
+
+        protected virtual void OnAdd(Type targetSystem, Type systemType, UpdateSubSystemInsertion insertion)
+        {
+            PlayerLoopSystem playerLoop = GetPlayerLoop();
+
+            if (UpdateUtility.TryAddSubSystem(ref playerLoop, targetSystem, systemType, insertion))
+            {
+                SetPlayerLoop(playerLoop);
+            }
+            else
+            {
+                throw new ArgumentException($"Adding system failed by the specified target system and system type: '{targetSystem}', '{systemType}'.");
+            }
+        }
+
+        protected virtual bool OnRemove(Type systemType)
+        {
+            PlayerLoopSystem playerLoop = GetPlayerLoop();
+
+            if (UpdateUtility.TryRemoveSubSystem(ref playerLoop, systemType))
+            {
+                SetPlayerLoop(playerLoop);
+                return true;
+            }
+
+            return false;
+        }
+
+        protected virtual void OnAddFunction(Type systemType, PlayerLoopSystem.UpdateFunction updateFunction)
+        {
+            PlayerLoopSystem playerLoop = GetPlayerLoop();
+
+            if (!UpdateUtility.TryAddUpdateFunction(playerLoop, systemType, updateFunction))
+            {
+                throw new ArgumentException($"Adding update function failed by the specified system type: '{systemType}'.");
+            }
+        }
+
+        protected virtual void OnRemoveFunction(Type systemType, PlayerLoopSystem.UpdateFunction updateFunction)
+        {
+            PlayerLoopSystem playerLoop = GetPlayerLoop();
+
+            if (!UpdateUtility.TryRemoveUpdateFunction(playerLoop, systemType, updateFunction))
+            {
+                throw new AggregateException($"Removing update function failed by the specified system type: '{systemType}'.");
+            }
+        }
+
+        protected abstract PlayerLoopSystem OnGetPlayerLoop();
+        protected abstract void OnSetPlayerLoop(PlayerLoopSystem playerLoop);
+        protected abstract void OnReset();
+    }
+}

--- a/Packages/UGF.Update/Runtime/UpdateLoopBase.cs.meta
+++ b/Packages/UGF.Update/Runtime/UpdateLoopBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ddabb7177ef645889353cfe0605904c1
+timeCreated: 1605638715

--- a/Packages/UGF.Update/Runtime/UpdateLoopUnity.cs
+++ b/Packages/UGF.Update/Runtime/UpdateLoopUnity.cs
@@ -5,19 +5,19 @@ namespace UGF.Update.Runtime
     /// <summary>
     /// Represents update loop access of the Unity player loop system.
     /// </summary>
-    public class UpdateLoopUnity : IUpdateLoop
+    public class UpdateLoopUnity : UpdateLoopBase
     {
-        public PlayerLoopSystem GetPlayerLoop()
+        protected override PlayerLoopSystem OnGetPlayerLoop()
         {
             return PlayerLoop.GetCurrentPlayerLoop();
         }
 
-        public void SetPlayerLoop(PlayerLoopSystem playerLoop)
+        protected override void OnSetPlayerLoop(PlayerLoopSystem playerLoop)
         {
             PlayerLoop.SetPlayerLoop(playerLoop);
         }
 
-        public void Reset()
+        protected override void OnReset()
         {
             UpdateUtility.ResetPlayerLoopToDefault();
         }

--- a/Packages/UGF.Update/Runtime/UpdateProvider.cs
+++ b/Packages/UGF.Update/Runtime/UpdateProvider.cs
@@ -29,6 +29,13 @@ namespace UGF.Update.Runtime
         }
 
         /// <summary>
+        /// Creates provider with default Unity update loop.
+        /// </summary>
+        public UpdateProvider() : this(new UpdateLoopUnity())
+        {
+        }
+
+        /// <summary>
         /// Creates provider with the specified update loop.
         /// </summary>
         /// <param name="updateLoop">The update loop to use.</param>

--- a/Packages/UGF.Update/Runtime/UpdateProvider.cs
+++ b/Packages/UGF.Update/Runtime/UpdateProvider.cs
@@ -44,17 +44,9 @@ namespace UGF.Update.Runtime
             if (updateGroup == null) throw new ArgumentNullException(nameof(updateGroup));
             if (m_groups.ContainsKey(updateGroup.Name)) throw new ArgumentException($"A group with the same name already exists: '{updateGroup.Name}'.", nameof(updateGroup));
 
-            PlayerLoopSystem playerLoop = UpdateLoop.GetPlayerLoop();
-            PlayerLoopSystem.UpdateFunction updateFunction = updateGroup.Update;
+            var info = new GroupInfo(subSystemType, updateGroup.Update);
 
-            if (!UpdateUtility.TryAddUpdateFunction(playerLoop, subSystemType, updateFunction))
-            {
-                throw new ArgumentException($"Change update loop failed with the specified subsystem type: '{subSystemType}'.");
-            }
-
-            UpdateLoop.SetPlayerLoop(playerLoop);
-
-            var info = new GroupInfo(subSystemType, updateFunction);
+            UpdateLoop.AddFunction(subSystemType, info.UpdateFunction);
 
             m_groups.Add(updateGroup.Name, updateGroup);
             m_infos.Add(updateGroup.Name, info);
@@ -73,13 +65,9 @@ namespace UGF.Update.Runtime
 
             if (m_groups.Remove(groupName))
             {
-                PlayerLoopSystem playerLoop = UpdateLoop.GetPlayerLoop();
                 GroupInfo info = m_infos[groupName];
 
-                if (UpdateUtility.TryRemoveUpdateFunction(playerLoop, info.SubSystemType, info.UpdateFunction))
-                {
-                    UpdateLoop.SetPlayerLoop(playerLoop);
-                }
+                UpdateLoop.RemoveFunction(info.SubSystemType, info.UpdateFunction);
 
                 m_infos.Remove(groupName);
             }
@@ -87,20 +75,9 @@ namespace UGF.Update.Runtime
 
         public void Clear()
         {
-            PlayerLoopSystem playerLoop = UpdateLoop.GetPlayerLoop();
-            bool changed = false;
-
             foreach (KeyValuePair<string, GroupInfo> pair in m_infos)
             {
-                if (UpdateUtility.TryRemoveUpdateFunction(playerLoop, pair.Value.SubSystemType, pair.Value.UpdateFunction))
-                {
-                    changed = true;
-                }
-            }
-
-            if (changed)
-            {
-                UpdateLoop.SetPlayerLoop(playerLoop);
+                UpdateLoop.RemoveFunction(pair.Value.SubSystemType, pair.Value.UpdateFunction);
             }
 
             m_groups.Clear();


### PR DESCRIPTION
- Add `IUpdateLoop.Contains`, `Add`, `Remove`, `AddFunction` and `RemoveFunction` methods to change player loop.
- Add `UpdateLoopBase` abstract class as default implementation of some methods of `IUpdateLoop` interface.
- Change `UpdateLoopUnity` to inherit from `UpdateLoopBase` and implement required members.
- Change `UpdateProvider` to work only through `IUpdateLoop` object passed on construction.