### PR TITLE
Fix print update group does not print type of subgroup

### DIFF
--- a/Packages/UGF.Update/Runtime/UpdateGroup.cs
+++ b/Packages/UGF.Update/Runtime/UpdateGroup.cs
@@ -39,7 +39,7 @@ namespace UGF.Update.Runtime
             SubGroups = new ReadOnlyCollection<IUpdateGroup>(m_subGroups);
 
 #if ENABLE_PROFILER
-            m_marker = new ProfilerMarker($"UpdateGroup.{Name}");
+            m_marker = new ProfilerMarker($"{GetType()} ({Name})");
 #else
             m_marker = default;
 #endif

--- a/Packages/UGF.Update/Runtime/UpdateUtility.cs
+++ b/Packages/UGF.Update/Runtime/UpdateUtility.cs
@@ -376,7 +376,7 @@ namespace UGF.Update.Runtime
             if (indent < 0) throw new ArgumentOutOfRangeException(nameof(indent));
 
             builder.Append(' ', depth * indent);
-            builder.Append($"{group.Name} (enabled: {group.Enable})");
+            builder.Append($"{group.GetType()} (enabled: {group.Enable}, name: {group.Name})");
             builder.AppendLine();
 
             if (group.Collection.Count > 0)


### PR DESCRIPTION
- Fix `PrintUpdateGroup` to display type and name information.
- Change `UpdateGroup` profiler marker to display type and name of the group.