### PR TITLE
Remove UpdateSet constructor with optional parameter as null

### DIFF
--- a/Packages/UGF.Update/Runtime/UpdateSet.cs
+++ b/Packages/UGF.Update/Runtime/UpdateSet.cs
@@ -9,11 +9,11 @@ namespace UGF.Update.Runtime
     {
         private readonly HashSet<TItem> m_items;
 
-        /// <summary>
-        /// Creates update set with the specified update queue.
-        /// </summary>
-        /// <param name="queue">The update queue. (Default value is UpdateQueueSet)</param>
-        public UpdateSet(IUpdateQueue<TItem> queue = null) : base(new HashSet<TItem>(), queue ?? new UpdateQueueSet<TItem>())
+        public UpdateSet() : this(new UpdateQueueSet<TItem>())
+        {
+        }
+
+        public UpdateSet(IUpdateQueue<TItem> queue) : base(new HashSet<TItem>(), queue)
         {
             m_items = (HashSet<TItem>)Collection;
         }


### PR DESCRIPTION
- Remove `UpdateSet<T>` constructor with optional parameter, use overload instead.