### PR TITLE
Fix wrong exception type inside of OnRemoveFunction method

### DIFF
--- a/Packages/UGF.Update/Runtime/UpdateLoopBase.cs
+++ b/Packages/UGF.Update/Runtime/UpdateLoopBase.cs
@@ -116,7 +116,7 @@ namespace UGF.Update.Runtime
             }
             else
             {
-                throw new AggregateException($"Removing update function failed by the specified system type: '{systemType}'.");
+                throw new ArgumentException($"Removing update function failed by the specified system type: '{systemType}'.");
             }
         }
 


### PR DESCRIPTION
- Fix `UpdateLoopBase.OnRemoveFunction` wrong type of exception is thrown, replace `AggregateException` by `ArgumentException` exception.